### PR TITLE
Use ConfigurableExtensionInterface

### DIFF
--- a/src/CommonMark/PhikiExtension.php
+++ b/src/CommonMark/PhikiExtension.php
@@ -4,11 +4,13 @@ namespace Phiki\CommonMark;
 
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
-use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use Phiki\Phiki;
 use Phiki\Theme\Theme;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
 
-class PhikiExtension implements ExtensionInterface
+class PhikiExtension implements ConfigurableExtensionInterface
 {
     /**
      * @param  bool  $withGutter  Include a gutter in the generated HTML. The gutter typically contains line numbers and helps provide context for the code.
@@ -21,9 +23,27 @@ class PhikiExtension implements ExtensionInterface
         private bool $withWrapper = false,
     ) {}
 
+    public function configureSchema(ConfigurationBuilderInterface $builder): void
+    {
+        $builder->addSchema('phiki', Expect::structure([
+            'theme' => Expect::mixed()->default($this->theme),
+            'with_gutter' => Expect::bool()->default($this->withGutter),
+            'with_wrapper' => Expect::bool()->default($this->withWrapper),
+        ]));
+    }
+
     public function register(EnvironmentBuilderInterface $environment): void
     {
-        $environment
-            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->theme, $this->phiki, $this->withGutter, $this->withWrapper), 10);
+        $config = $environment->getConfiguration();
+
+        $theme = $config->get('phiki/theme');
+        $withGutter = $config->get('phiki/with_gutter');
+        $withWrapper = $config->get('phiki/with_wrapper');
+
+        $environment->addRenderer(
+            FencedCode::class,
+            new CodeBlockRenderer($theme, $this->phiki, $withGutter, $withWrapper),
+            10,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- use `ConfigurableExtensionInterface`
- expose gutter and wrapper settings through CommonMark config builder
- pull settings from configuration when registering the renderer

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`